### PR TITLE
fix website-mapping if website attribute is specified in configuration 

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1256,11 +1256,8 @@ class Product extends Import
                     if ($associatedWebsites != null) {
                         /** @var Select $deleteSelect */
                         $deleteSelect = $connection->select()->from(
-                            $this->entitiesHelper->getTable('catalog_product_website'),
-                            [
-                                'product_id' => new Expr($row['entity_id']),
-                            ]
-                        );
+                            $this->entitiesHelper->getTable('catalog_product_website')
+                        )->where('product_id = ?', $row['entity_id']);
 
                         $connection->query(
                             $connection->deleteFromSelect(


### PR DESCRIPTION
When a website attribute is specified all present associations are deleted through this query

https://github.com/akeneo/magento2-connector-community/blob/9edbe8fc5d394faca767df9e5974787b936396da/Job/Product.php#L1257-L1263

This will result in the following sql-statement when deleteFromSelect gets called at https://github.com/akeneo/magento2-connector-community/blob/master/Job/Product.php#L1265

`DELETE `catalog_product_website`  FROM `catalog_product_website``

I have rewritten the deleteSelect to only select the mappings for the current product
