### PR TITLE
added loading of default attribute-set id for categories

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -834,4 +834,16 @@ class Config extends AbstractHelper
 
         return $loweredMatches;
     }
+
+    /**
+     * Returns default attribute-set id for given entity
+     *
+     * @param string $entity
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getDefaultAttributeSetId($entity)
+    {
+        return $this->eavConfig->getEntityType($entity)->getDefaultAttributeSetId();
+    }
 }

--- a/Job/Category.php
+++ b/Job/Category.php
@@ -397,7 +397,7 @@ class Category extends Import
         /** @var array $values */
         $values = [
             'entity_id'        => '_entity_id',
-            'attribute_set_id' => new Expr($this->configHelper->getEntityTypeId(CategoryModel::ENTITY)),
+            'attribute_set_id' => new Expr($this->configHelper->getDefaultAttributeSetId(CategoryModel::ENTITY)),
             'parent_id'        => 'parent_id',
             'updated_at'       => new Expr('now()'),
             'path'             => 'path',


### PR DESCRIPTION
The current implementation assumes that the categories' entity-id matches their attribute-set id. This is true for plain Magento installations, but might not be true in other circumstances (e.g. if a data-migration from Magento 1 took place). In those cases a wrong attribute-set id leads to missing attributes and manual editing of categories being impossible.

The implementation was changed to a solution that works both for plain installations and migrated data.