### PR TITLE
Fix/urlkey update

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1780,8 +1780,6 @@ class Product extends Import
             $this->storeHelper->getStores(['lang']), // en_US
             $this->storeHelper->getStores(['lang', 'channel_code']) // en_US-channel
         );
-        /** @var bool $isUrlKeyMapped */
-        $isUrlKeyMapped = $this->configHelper->isUrlKeyMapped();
 
         $defaultUrlKeyColumn = '`url_key`';
         /**

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1783,6 +1783,7 @@ class Product extends Import
         /** @var bool $isUrlKeyMapped */
         $isUrlKeyMapped = $this->configHelper->isUrlKeyMapped();
 
+        $defaultUrlKeyColumn = '`url_key`';
         /**
          * @var string $local
          * @var array  $affected
@@ -1800,8 +1801,9 @@ class Product extends Import
                         'nullable' => false,
                     ]
                 );
-                $connection->update($tmpTable, ['url_key-' . $local => new Expr('`url_key`')]);
+                $connection->update($tmpTable, ['url_key-' . $local => new Expr($defaultUrlKeyColumn)]);
             }
+            $defaultUrlKeyColumn = "`url_key-$local`";
 
             /**
              * @var array $affected


### PR DESCRIPTION
In case le url_key field in akeneo is defined only on the locale and not in the channel, there was a double update on the urlrewite, the second updating it on the url_key fallback field (identifier value) .

This PR fix this.

