### PR TITLE
Fix processing of metric attributes on variants

### DIFF
--- a/Job/Attribute.php
+++ b/Job/Attribute.php
@@ -177,8 +177,8 @@ class Attribute extends Import
          */
         foreach ($attributes as $index => $attribute) {
             /** @var string $attributeCode */
-            $attributeCode     = strtolower($attribute['code']);
-            $attribute['code'] = $attributeCode;
+            $attributeCode     = $attribute['code'];
+            $attribute['code'] = strtolower($attributeCode);
 
             if ($attribute['type'] == 'pim_catalog_metric' && in_array(
                     $attributeCode,

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -34,7 +34,6 @@ use Akeneo\Connector\Helper\Serializer as JsonSerializer;
 use Akeneo\Connector\Helper\Import\Product as ProductImportHelper;
 use Akeneo\Connector\Job\Option as JobOption;
 use Akeneo\Connector\Model\Source\Attribute\Metrics as AttributeMetrics;
-use Magento\Backend\Model\Locale\Manager as LocaleManager;
 use Zend_Db_Expr as Expr;
 use Zend_Db_Statement_Pdo;
 
@@ -209,12 +208,6 @@ class Product extends Import
      */
     protected $jobOption;
     /**
-     * This variable contains a LocaleManager
-     *
-     * @var LocaleManager $localeManager
-     */
-    protected $localeManager;
-    /**
      * This variable contains an AttributeMetrics
      *
      * @var AttributeMetrics $attributeMetrics
@@ -244,7 +237,6 @@ class Product extends Import
      * @param TypeListInterface       $cacheTypeList
      * @param StoreHelper             $storeHelper
      * @param LocalesHelper           $localesHelper
-     * @param LocaleManager           $localeManager
      * @param AttributeMetrics        $attributeMetrics
      * @param StoreManagerInterface   $storeManager
      * @param array                   $data
@@ -265,7 +257,6 @@ class Product extends Import
         StoreHelper $storeHelper,
         LocalesHelper $localesHelper,
         JobOption $jobOption,
-        LocaleManager $localeManager,
         AttributeMetrics $attributeMetrics,
         StoreManagerInterface $storeManager,
         array $data = []
@@ -283,7 +274,6 @@ class Product extends Import
         $this->storeHelper             = $storeHelper;
         $this->localesHelper           = $localesHelper;
         $this->jobOption               = $jobOption;
-        $this->localeManager           = $localeManager;
         $this->productUrlPathGenerator = $productUrlPathGenerator;
         $this->attributeMetrics        = $attributeMetrics;
         $this->storeManager            = $storeManager;
@@ -620,10 +610,8 @@ class Product extends Import
         $tmpTable = $this->entitiesHelper->getTableName($this->getCode());
         /** @var mixed[] $metricsVariantSettings */
         $metricsVariantSettings = $this->configHelper->getMetricsColumns(true);
-        /** @var string[] $metricsSymbols */
-        $metricsSymbols = $this->getMetricsSymbols();
-        /** @var string $adminLocale */
-        $adminLocale = $this->localeManager->getGeneralLocale();
+        /** @var string[] $locales */
+        $locales = $this->localesHelper->getAkeneoLocales();
 
         $this->jobOption->createTable();
 
@@ -646,9 +634,7 @@ class Product extends Import
                 }
 
                 /** @var string[] $labels */
-                $labels = [];
-
-                $labels[$adminLocale] = $option;
+                $labels = array_fill_keys($locales, $option);
 
                 /** @var mixed[] $insertedData */
                 $insertedData = [

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -628,6 +628,7 @@ class Product extends Import
         $this->jobOption->createTable();
 
         foreach ($metricsVariantSettings as $metricsVariantSetting) {
+            $metricsVariantSetting = strtolower($metricsVariantSetting);
             $columnExist = $connection->tableColumnExists($tmpTable, $metricsVariantSetting);
 
             if (!$columnExist) {

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -28,7 +28,6 @@ use Akeneo\Connector\Helper\Authenticator;
 use Akeneo\Connector\Helper\Config as ConfigHelper;
 use Akeneo\Connector\Helper\Output as OutputHelper;
 use Akeneo\Connector\Helper\Store as StoreHelper;
-use Akeneo\Connector\Helper\Locales as LocalesHelper;
 use Akeneo\Connector\Helper\ProductFilters;
 use Akeneo\Connector\Helper\Serializer as JsonSerializer;
 use Akeneo\Connector\Helper\Import\Product as ProductImportHelper;
@@ -196,12 +195,6 @@ class Product extends Import
      */
     protected $storeHelper;
     /**
-     * This variable contains a LocalesHelper
-     *
-     * @var LocalesHelper $localesHelper
-     */
-    protected $localesHelper;
-    /**
      * This variable contains a JobOption
      *
      * @var JobOption $jobOption
@@ -236,7 +229,6 @@ class Product extends Import
      * @param ProductUrlPathGenerator $productUrlPathGenerator
      * @param TypeListInterface       $cacheTypeList
      * @param StoreHelper             $storeHelper
-     * @param LocalesHelper           $localesHelper
      * @param AttributeMetrics        $attributeMetrics
      * @param StoreManagerInterface   $storeManager
      * @param array                   $data
@@ -255,7 +247,6 @@ class Product extends Import
         ProductUrlPathGenerator $productUrlPathGenerator,
         TypeListInterface $cacheTypeList,
         StoreHelper $storeHelper,
-        LocalesHelper $localesHelper,
         JobOption $jobOption,
         AttributeMetrics $attributeMetrics,
         StoreManagerInterface $storeManager,
@@ -272,7 +263,6 @@ class Product extends Import
         $this->product                 = $product;
         $this->cacheTypeList           = $cacheTypeList;
         $this->storeHelper             = $storeHelper;
-        $this->localesHelper           = $localesHelper;
         $this->jobOption               = $jobOption;
         $this->productUrlPathGenerator = $productUrlPathGenerator;
         $this->attributeMetrics        = $attributeMetrics;
@@ -371,8 +361,10 @@ class Product extends Import
                     foreach ($product['values'][$metricsConcatSetting] as $key => $metric) {
                         /** @var string $unit */
                         $unit = $metric['data']['unit'];
+                        /** @var string|false $symbol */
+                        $symbol = array_key_exists($unit, $metricSymbols);
 
-                        if (!array_key_exists($unit, $metricSymbols)) {
+                        if (!$symbol) {
                             continue;
                         }
 
@@ -609,7 +601,7 @@ class Product extends Import
         /** @var mixed[] $metricsVariantSettings */
         $metricsVariantSettings = $this->configHelper->getMetricsColumns(true);
         /** @var string[] $locales */
-        $locales = $this->localesHelper->getAkeneoLocales();
+        $locales = $this->storeHelper->getMappedWebsitesStoreLangs();
 
         $this->jobOption->createTable();
 

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -371,8 +371,6 @@ class Product extends Import
                     foreach ($product['values'][$metricsConcatSetting] as $key => $metric) {
                         /** @var string $unit */
                         $unit = $metric['data']['unit'];
-                        /** @var string|false $symbol */
-                        $symbol = array_key_exists($unit, $metricSymbols);
 
                         if (!array_key_exists($unit, $metricSymbols)) {
                             continue;


### PR DESCRIPTION
Trying to implement configurable products using the new option for using metric attributes as variants I found a couple of problems in the implementation.

1) It fails if the attributes have uppercase letters (in our case we had some camelCased names). There are 2 points of failure:
    1) When saving the config in the admin, it uses the original name, but in the import attribute job it lowercases the name before comparing with the config to see it it should be a "_select" type.
    2) When creating the options during the product import, it compares the value from the config against the column names, but the column names are lowercased during insertDataFromApi() so it fails to create any option.
2) When creating the Options, Job\Product and Job\Option use different ways to get a default locale and creation might fail because of a validation on Job\Option::insertOptions().
Both methods query the same config path, but use different scope, and in the case of our multilocale store it returned different values.
Job\Product uses `\Magento\Backend\Model\Locale\Manager::getGeneralLocale()` (scope default)
Job\Option uses `\Akeneo\Connector\Helper\Config::getDefaultLocale()` (scope store)

For 1), I applied lowercasing on the appropiate part of the process (it could be done at the config save in the backend, but didn't want to affect something else). For 2), I used the the locales setup on Akeneo, so the value is in all of them.
Also I removed a duplicated call to array_key_exists

