### PR TITLE
Skip url generation of variant products

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1842,6 +1842,7 @@ class Product extends Import
                         'entity_id' => '_entity_id',
                         'url_key'   => 'url_key-' . $local,
                         'store_id'  => new Expr($store['store_id']),
+                        'visibility' => '_visibility',
                     ]
                 );
 
@@ -1857,7 +1858,7 @@ class Product extends Import
                     /** @var string $urlPath */
                     $urlPath = $this->productUrlPathGenerator->getUrlPath($product);
 
-                    if (!$urlPath) {
+                    if (!$urlPath || $row['visibility'] < 2) {
                         continue;
                     }
 


### PR DESCRIPTION
Don't generate urls for simple product which are not visible in the frontend.

In the current situation when you run the url generation, all product urls are generated. This is not necessary and results in wrong product urls of simple products part of configurable products. Example before:

![Screenshot 2020-02-12 at 17 20 12](https://user-images.githubusercontent.com/14089150/74354644-f56ce900-4dbb-11ea-8b7a-0bd1ec574c7e.png)

Product New Balance Q Speed Jacquard Tank Damen `entity: 83448` must have the url `new-balance-q-speed-jacquard-tank-damen-wt01254ps2`, but the variant of L (size) `entity: 83483` has the configurable url `new-balance-q-speed-jacquard-tank-damen-wt01254ps2`.

After optimalisation:

![Screenshot 2020-02-12 at 17 18 20](https://user-images.githubusercontent.com/14089150/74354461-b048b700-4dbb-11ea-8909-bb339a8bb630.png)

Simple check on visibility sound like the right solution.
