### PR TITLE
Allow configurables to have metric attributes

### DIFF
--- a/Job/ProductModel.php
+++ b/Job/ProductModel.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Connector\Job;
 
+use Akeneo\Connector\Model\Source\Attribute\Metrics as AttributeMetrics;
 use Akeneo\Pim\ApiClient\Pagination\PageInterface;
 use Akeneo\Pim\ApiClient\Pagination\ResourceCursorInterface;
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
@@ -55,17 +56,22 @@ class ProductModel extends Import
      * @var Config $eavConfig
      */
     protected $eavConfig;
+    /**
+     * @var AttributeMetrics
+     */
+    protected $attributeMetrics;
 
     /**
      * ProductModel constructor
      *
-     * @param OutputHelper                        $outputHelper
-     * @param ManagerInterface                    $eventManager
-     * @param Authenticator                       $authenticator
+     * @param OutputHelper                            $outputHelper
+     * @param ManagerInterface                        $eventManager
+     * @param Authenticator                           $authenticator
      * @param \Akeneo\Connector\Helper\Import\Product $entitiesHelper
-     * @param ConfigHelper                        $configHelper
-     * @param Config                              $eavConfig
-     * @param array                               $data
+     * @param ConfigHelper                            $configHelper
+     * @param Config                                  $eavConfig
+     * @param AttributeMetrics                        $attributeMetrics
+     * @param array                                   $data
      */
     public function __construct(
         OutputHelper $outputHelper,
@@ -74,6 +80,7 @@ class ProductModel extends Import
         \Akeneo\Connector\Helper\Import\Product $entitiesHelper,
         ConfigHelper $configHelper,
         Config $eavConfig,
+        AttributeMetrics $attributeMetrics,
         array $data = []
     ) {
         parent::__construct($outputHelper, $eventManager, $authenticator, $data);
@@ -81,6 +88,7 @@ class ProductModel extends Import
         $this->entitiesHelper  = $entitiesHelper;
         $this->configHelper    = $configHelper;
         $this->eavConfig       = $eavConfig;
+        $this->attributeMetrics = $attributeMetrics;
     }
 
     /**
@@ -115,17 +123,90 @@ class ProductModel extends Import
         $paginationSize = $this->configHelper->getPanigationSize();
         /** @var ResourceCursorInterface $productModels */
         $productModels = $this->akeneoClient->getProductModelApi()->all($paginationSize);
+
+        /** @var string[] $attributeMetrics */
+        $attributeMetrics = $this->attributeMetrics->getMetricsAttributes();
+        /** @var mixed[] $metricsConcatSettings */
+        $metricsConcatSettings = $this->configHelper->getMetricsColumns(null, true);
+        /** @var string[] $metricSymbols */
+        $metricSymbols = $this->getMetricsSymbols();
+
         /**
          * @var int   $index
          * @var array $productModel
          */
         foreach ($productModels as $index => $productModel) {
+
+
+            foreach ($attributeMetrics as $attributeMetric) {
+                if (!isset($productModel['values'][$attributeMetric])) {
+                    continue;
+                }
+
+                foreach ($productModel['values'][$attributeMetric] as $key => $metric) {
+                    /** @var string|float $amount */
+                    $amount = $metric['data']['amount'];
+                    $amount = floatval($amount);
+
+                    $productModel['values'][$attributeMetric][$key]['data']['amount'] = $amount;
+                }
+            }
+
+            /**
+             * @var mixed[] $metricsConcatSetting
+             */
+            foreach ($metricsConcatSettings as $metricsConcatSetting) {
+                if (!isset($productModel['values'][$metricsConcatSetting])) {
+                    continue;
+                }
+
+                /**
+                 * @var int     $key
+                 * @var mixed[] $metric
+                 */
+                foreach ($productModel['values'][$metricsConcatSetting] as $key => $metric) {
+                    /** @var string $unit */
+                    $unit = $metric['data']['unit'];
+                    /** @var string|false $symbol */
+                    $symbol = array_key_exists($unit, $metricSymbols);
+
+                    if (!$symbol) {
+                        continue;
+                    }
+
+                    $productModel['values'][$metricsConcatSetting][$key]['data']['amount'] .= ' ' . $metricSymbols[$unit];
+                }
+            }
+
+
             $this->entitiesHelper->insertDataFromApi($productModel, $this->getCode());
         }
         $index++;
         $this->setMessage(
             __('%1 line(s) found', $index)
         );
+    }
+
+    /**
+     * Generate array of metrics with unit in key and symbol for value
+     *
+     * @return string[]
+     */
+    public function getMetricsSymbols()
+    {
+        /** @var mixed[] $measures */
+        $measures = $this->akeneoClient->getMeasureFamilyApi()->all();
+        /** @var string[] $metricsSymbols */
+        $metricsSymbols = [];
+        /** @var mixed[] $measure */
+        foreach ($measures as $measure) {
+            /** @var mixed[] $unit */
+            foreach ($measure['units'] as $unit) {
+                $metricsSymbols[$unit['code']] = $unit['symbol'];
+            }
+        }
+
+        return $metricsSymbols;
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -307,12 +307,12 @@
                         <item name="comment" xsi:type="string">Add required data</item>
                     </item>
                     <item name="4" xsi:type="array">
-                        <item name="method" xsi:type="string">createMetricsOptions</item>
-                        <item name="comment" xsi:type="string">Create Options for Variant Metrics Attributes</item>
-                    </item>
-                    <item name="5" xsi:type="array">
                         <item name="method" xsi:type="string">createConfigurable</item>
                         <item name="comment" xsi:type="string">Create configurables</item>
+                    </item>
+                    <item name="5" xsi:type="array">
+                        <item name="method" xsi:type="string">createMetricsOptions</item>
+                        <item name="comment" xsi:type="string">Create Options for Variant Metrics Attributes</item>
                     </item>
                     <item name="6" xsi:type="array">
                         <item name="method" xsi:type="string">checkEntities</item>


### PR DESCRIPTION
If I set a metric attribute on the config to be imported with its unit, and then try to map it on the configurable parents (Product Model in Akeneo), the value will fail to set.

The problem is that the decimal value is imported on the Product model job (ex 40.0000), but the values on the dropdown attribute are created from the formatted string ("40 cm"), so it will fail the comparison on the updateOption step.

I copied the code from the Product job (it probably should be moved to a Metrics helper or something like that), and also change the order of the steps so if there are values on a Model that is not used on a simple product, the option is created correctly.