### PR TITLE
Afin de permettre l'usage des plugins Interceptor

### DIFF
--- a/Job/ImportRepository.php
+++ b/Job/ImportRepository.php
@@ -75,14 +75,7 @@ class ImportRepository implements ImportRepositoryInterface
      */
     private function initCollection($data)
     {
-        foreach ($data as $id => $class) {
-            if (!class_exists($class)) {
-                continue;
-            }
-
-            /** @var Import $import */
-            $import = $this->entityFactory->create($class);
-
+        foreach ($data as $id => $import) {
             $import->setData('id', $id);
             $this->add($import);
         }


### PR DESCRIPTION
Pour permettre l'usage des plugins Interceptor Magento2 (before, after, around)
Modification du di.xml associé pour une déclaration des job conforme à cet usage
déclaration des jobs en tant qu'object au lieu de string

              <item name="category" xsi:type="object">\Akeneo\Connector\Job\Category</item>
                <item name="family" xsi:type="object">\Akeneo\Connector\Job\Family</item>
                <item name="attribute" xsi:type="object">\Akeneo\Connector\Job\Attribute</item>
                <item name="option" xsi:type="object">\Akeneo\Connector\Job\Option</item>
                <item name="product_model" xsi:type="object">\Akeneo\Connector\Job\ProductModel</item>
                <item name="family_variant" xsi:type="object">\Akeneo\Connector\Job\FamilyVariant</item>
                <item name="product" xsi:type="object">\Akeneo\Connector\Job\Product</item>