### PR TITLE
Handle category url_path attribute

### DIFF
--- a/Job/Category.php
+++ b/Job/Category.php
@@ -704,11 +704,23 @@ class Category extends Import
                         );
 
                     if ($rewriteId) {
-                        $connection->update(
-                            $this->entitiesHelper->getTable('url_rewrite'),
-                            ['request_path' => $requestPath],
-                            ['url_rewrite_id = ?' => $rewriteId]
-                        );
+                        try {
+                            $connection->update(
+                                $this->entitiesHelper->getTable('url_rewrite'),
+                                ['request_path' => $requestPath],
+                                ['url_rewrite_id = ?' => $rewriteId]
+                            );
+                        } catch (\Exception $e) {
+                            $this->setAdditionalMessage(
+                                __(
+                                    sprintf(
+                                        'Tried to update url_rewrite_id %s : request path (%s) already exists for the store_id.',
+                                        $rewriteId,
+                                        $requestPath
+                                    )
+                                )
+                            );
+                        }
                     } else {
                         /** @var array $data */
                         $data = [

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -11,8 +11,8 @@ use Akeneo\Connector\Helper\Output as OutputHelper;
 use Akeneo\Connector\Helper\ProductFilters;
 use Akeneo\Connector\Helper\Serializer as JsonSerializer;
 use Akeneo\Connector\Helper\Store as StoreHelper;
-use Akeneo\Connector\Job\Option as JobOption;
 use Akeneo\Connector\Job\Import as JobImport;
+use Akeneo\Connector\Job\Option as JobOption;
 use Akeneo\Connector\Model\Source\Attribute\Metrics as AttributeMetrics;
 use Akeneo\Connector\Model\Source\Filters\Mode;
 use Akeneo\Pim\ApiClient\Pagination\PageInterface;
@@ -2321,11 +2321,23 @@ class Product extends JobImport
                         );
 
                         if ($rewriteId) {
-                            $connection->update(
-                                $this->entitiesHelper->getTable('url_rewrite'),
-                                ['request_path' => $requestPath, 'metadata' => $metadata],
-                                ['url_rewrite_id = ?' => $rewriteId]
-                            );
+                            try {
+                                $connection->update(
+                                    $this->entitiesHelper->getTable('url_rewrite'),
+                                    ['request_path' => $requestPath, 'metadata' => $metadata],
+                                    ['url_rewrite_id = ?' => $rewriteId]
+                                );
+                            } catch (\Exception $e) {
+                                $this->setAdditionalMessage(
+                                    __(
+                                        sprintf(
+                                            'Tried to update url_rewrite_id %s : request path (%s) already exists for the store_id.',
+                                            $rewriteId,
+                                            $requestPath
+                                        )
+                                    )
+                                );
+                            }
                         } else {
                             /** @var array $data */
                             $data = [


### PR DESCRIPTION
Bad url_rewrite happened with the following use case : 
- let's you have this categroy tree in Akeneo 
```
- Femme (Woman)
    |- Chemise (Shirt)
```
- on a Magento 2 with 2 store view using 2 differents locales (let's say fr_FR and en_US). Default store view is the fr_FR one.
- import categories : category's url keys (`femme`/`woman` for example) are set but url paths aren't
- in Magento backend save the "Femme" category in the default store view : url_path is set (to `femme`) for this category in the default store (id : 0). url_path in other store view still not exists
- import categories again : url_rewrite in the en_US store view will be corrupted. You'll get : `femme/shirt.html` instead of `woman/shirt.html`