### PR TITLE
Fix invalid variable used to search in array

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -2622,7 +2622,7 @@ class Product extends JobImport
         $mode = $this->configHelper->getFilterMode();
         if ($mode == Mode::ADVANCED) {
             /** @var string[] $filters */
-            $filters = $this->configHelper->getAdvancedFilters();
+            $advancedFilters = $this->configHelper->getAdvancedFilters();
             if (isset($advancedFilters['search']['family'])) {
                 foreach ($advancedFilters['search']['family'] as $key => $familyFilter) {
                     if (isset($familyFilter['operator']) && $familyFilter['operator'] == 'NOT IN') {

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -2627,7 +2627,7 @@ class Product extends JobImport
                 foreach ($advancedFilters['search']['family'] as $key => $familyFilter) {
                     if (isset($familyFilter['operator']) && $familyFilter['operator'] == 'NOT IN') {
                         foreach ($familyFilter['value'] as $familyToRemove) {
-                            if (($familyKey = array_search($familyFilter, $families)) !== false) {
+                            if (($familyKey = array_search($familyToRemove, $families)) !== false) {
                                 unset($families[$familyKey]);
                             }
                         }


### PR DESCRIPTION
When using the advanced filter, all the families are tested anyway, because the incorrect variable being used to check