### PR TITLE
Fix file import with uppercase attribute codes

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1266,6 +1266,8 @@ class Product extends JobImport
 
         // Get all attributes to import
         foreach ($attributesMapped as $attribute) {
+            $attribute = strtolower($attribute);
+
             /** @var bool $attributeUsed */
             if ($connection->tableColumnExists($tmpTable, $attribute)) {
                 $data[$attribute] = $attribute;


### PR DESCRIPTION
In case a file attribute code on akeneo side has uppercase letters, the file import will not work at all for that attribute. This fix adds `strtolower` to `importFiles` of the product import, which should resolve this issue.

This fixes issue: #274 