### PR TITLE
Escape html in phtml. Shortcuts instead echo.

### DIFF
--- a/view/adminhtml/templates/import.phtml
+++ b/view/adminhtml/templates/import.phtml
@@ -14,14 +14,14 @@
 ?>
 <div class="akeneo-connector-uploader">
   <div class="akeneo-connector-step">
-    <h2><?php echo __('Select import type:') ?></h2>
+    <h2><?= $block->escapeHtml(__('Select import type:')) ?></h2>
     <div class="akeneo-connector-types">
         <?php $collection = $block->getCollection() ?>
         <?php /** @var mixed $import */ ?>
         <?php foreach ($collection as $import): ?>
             <?php if ($block->isAllowed($import->getCode())): ?>
-            <div class="import-type" onclick="Akeneo_Connector.type('<?php echo $import->getCode() ?>', this)">
-                <?php echo $import->getName() ?>
+            <div class="import-type" onclick="Akeneo_Connector.type('<?= /* @noEscape */ $import->getCode() ?>', this)">
+                <?= /* @noEscape */ $import->getName() ?>
             </div>
             <?php endif; ?>
         <?php endforeach; ?>
@@ -30,21 +30,21 @@
   <div class="akeneo-connector-step step-last">
     <button type="button" class="primary" onclick="launch()">
             <span class="ui-button-text">
-                <span><?php echo __('Import') ?></span>
+                <span><?= $block->escapeHtml(__('Import')) ?></span>
             </span>
     </button>
   </div>
 </div>
 
 <ul class="akeneo-connector-console">
-  <li class="selected"><?php echo __('Waiting for import...') ?></li>
+  <li class="selected"><?= $block->escapeHtml(__('Waiting for import...')) ?></li>
 </ul>
 
 <script>
 require(
     ["Akeneo_Connector/js/akeneo_connector"],
     function (akeneoConnector) {
-      akeneoConnector.init('<?php echo $runUrl; ?>', '<?php echo $runProductUrl; ?>', '.akeneo-connector-console');
+      akeneoConnector.init('<?= /* @noEscape */ $runUrl; ?>', '<?= /* @noEscape */ $runProductUrl; ?>', '.akeneo-connector-console');
       window.Akeneo_Connector = akeneoConnector;
     }
 );

--- a/view/adminhtml/templates/view.phtml
+++ b/view/adminhtml/templates/view.phtml
@@ -12,10 +12,10 @@
 <div class="page-main-actions">
     <div class="page-actions-placeholder"></div>
     <div class="page-actions" data-ui-id="page-actions-toolbar-content-header">
-        <div class="page-actions-inner" data-title="Performance">
+        <div class="page-actions-inner" data-title="<?= $block->escapeHtmlAttr(__('Performance')) ?>">
             <div class="page-actions-buttons">
-                <button type="button" class="action-default scalable action-back" onclick="setLocation('<?php echo $block->getBackUrl() ?>')" data-ui-id="page-actions-toolbar-back-button">
-                    <span><?php echo __('Back') ?></span>
+                <button type="button" class="action-default scalable action-back" onclick="setLocation('<?= $block->getBackUrl() ?>')" data-ui-id="page-actions-toolbar-back-button">
+                    <span><?= $block->escapeHtml(__('Back')) ?></span>
                 </button>
             </div>
         </div>
@@ -24,11 +24,11 @@
 
 <ul class="akeneo-connector-console">
     <?php $log = $block->getLog(); ?>
-    <li><?php echo $log->getCode() ?> <?php echo $log->getFile() ?></li>
+    <li><?= /* @noEscape */ $log->getCode() ?> <?= /* @noEscape */ $log->getFile() ?></li>
     <?php $steps = $block->getSteps(); ?>
     <?php $previous = null; ?>
     <?php foreach ($steps as $step): ?>
-        <li class="<?php echo !$step['status'] ? 'error' : ($previous == $step['number'] ? 'success' : '') ?>"><?php echo $step['message'] ?></li>
+        <li class="<?= /* @noEscape */ !$step['status'] ? 'error' : ($previous == $step['number'] ? 'success' : '') ?>"><?= /* @noEscape */ $step['message'] ?></li>
         <?php $previous = $step['number'] ?>
     <?php endforeach; ?>
 </ul>


### PR DESCRIPTION
Hi!

Added escaping for phrases and skip validation for block data.
In addition, Added using php shortcuts <?= ?> instead echo as recommended by Magento Guide Lines.

Please review,  