### PR TITLE
Fix images downloading always

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -2711,7 +2711,7 @@ class Product extends JobImport
                 /** @var string $filePath */
                 $filePath = $this->configHelper->getMediaFullPath($name);
 
-                if (!$this->configHelper->mediaFileExists($name)) {
+                if (!$this->configHelper->mediaFileExists($filePath)) {
                     /** @var ResponseInterface $binary */
                     $binary = $this->akeneoClient->getProductMediaFileApi()->download($row[$image]);
                     $this->configHelper->saveMediaFile($filePath, $binary);


### PR DESCRIPTION
on commit https://github.com/akeneo/magento2-connector-community/commit/0cc6e0fc2e912f0f7602f7edc381ba412ae22f76 mediaFIleExists was changed from using filename to filepath, but the parameter was only updated for importFiles. 
on importMedia, the check always fails, and so it downloads every image always