### PR TITLE
Fix incorrect column name, with the incorrect column name configurable products can not be imported

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -946,7 +946,7 @@ class Product extends JobImport
             '_type_id'           => new Expr('"configurable"'),
             '_options_container' => new Expr('"container1"'),
             '_axis'              => 'v.axis',
-            'family'             => 'v.family',
+            'family'             => 'v.family_variant',
             'categories'         => 'v.categories'
         ];
 


### PR DESCRIPTION
Example query error:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'v.family' in 'field list', query was: INSERT INTO `tmp_akeneo_connector_entities_product` (`identifier`, `_type_id`, `_options_container`, `_axis`, `family`, `categories`, `code`, `family_variant`, `parent`, `ec_versionid`, `ec_color_main`, `ec_name-de_DE`, `ec_name-en_GB`, `ec_name-fr_FR`, `ec_name-nl_NL`, `ec_modelid`, `ec_producttype`, `created`, `updated`, `_entity_id`, `_is_new`, `axis`, `ec_usp1-nl_NL`, `ec_usp2-nl_NL`, `ec_usp3-nl_NL`, `ec_label`, `ec_style`, `ec_b2b_only`, `ec_description-nl_NL`, `ec_homologation`, `ec_materials_main`, `ec_targetaudience`, `ec_materials_technical`, `weight`, `price-EUR`, `description-nl_NL`, `ec_brand`, `ec_title-en_GB`, `ec_title-nl_NL`, `ec_title-de_DE`, `ec_itemgroupname`, `ec_suppliercode`, `ec_weight`, `ec_salesforce_only`, `ec_rrp-EUR`) SELECT `v`.`code` AS `identifier`, "configurable" AS `_type_id`, "container1" AS `_options_container`, `v`.`axis` AS `_axis`, `v`.`family`, `v`.`categories`, `v`.`code`, `v`.`family_variant`, `v`.`parent`, `v`.`ec_versionid`, `v`.`ec_color_main`, `e`.`ec_name-de_DE`, `e`.`ec_name-en_GB`, `e`.`ec_name-fr_FR`, `e`.`ec_name-nl_NL`, `v`.`ec_modelid`, `e`.`ec_producttype`, `v`.`created`, `v`.`updated`, `v`.`_entity_id`, `v`.`_is_new`, `v`.`axis`, `e`.`ec_usp1-nl_NL`, `e`.`ec_usp2-nl_NL`, `e`.`ec_usp3-nl_NL`, `v`.`ec_label`, `e`.`ec_style`, `e`.`ec_b2b_only`, `v`.`ec_description-nl_NL`, `e`.`ec_homologation`, `e`.`ec_materials_main`, `e`.`ec_targetaudience`, `v`.`ec_materials_technical`, `e`.`weight`, `e`.`price-EUR`, `e`.`description-nl_NL`, `e`.`ec_brand`, `e`.`ec_title-en_GB`, `e`.`ec_title-nl_NL`, `e`.`ec_title-de_DE`, `e`.`ec_itemgroupname`, `e`.`ec_suppliercode`, `e`.`ec_weight`, `e`.`ec_salesforce_only`, `e`.`ec_rrp-EUR` FROM `tmp_akeneo_connector_entities_product_model` AS `v`
 LEFT JOIN `tmp_akeneo_connector_entities_product` AS `e` ON v.code = e.parent WHERE (v.parent IS NULL) GROUP BY `v`.`code`
```