### PR TITLE
Change configurable-children linking to avoid mysql limits

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1078,7 +1078,7 @@ class Product extends JobImport
         // Update _children column if possible
         /** @var Select $childList */
         $childList = $connection->select()
-            ->from(['v' => $productModelTable] , ['v.identifier', '_children' => new Expr('GROUP_CONCAT(e.identifier SEPARATOR ",")')])
+            ->from(['v' => $productModelTable] , ['v.identifier', '_children' => new Expr('"1"')])
             ->joinInner(['e' => $tmpTable],'v.code = ' . 'e.' . $groupColumn, [])
             ->group('v.identifier');
 
@@ -1737,7 +1737,7 @@ class Product extends JobImport
         }
 
         /** @var Select $configurableSelect */
-        $configurableSelect = $connection->select()->from($tmpTable, ['_entity_id', '_axis', '_children'])->where('_type_id = ?', 'configurable')->where('_axis IS NOT NULL');
+        $configurableSelect = $connection->select()->from($tmpTable, ['identifier','_entity_id', '_axis', '_children'])->where('_type_id = ?', 'configurable')->where('_axis IS NOT NULL');
 
         /** @var string $pKeyColumn */
         $pKeyColumn = '_entity_id';
@@ -1759,6 +1759,10 @@ class Product extends JobImport
         $query = $connection->query($configurableSelect);
         /** @var array $stores */
         $stores = $this->storeHelper->getStores('store_id');
+
+        $childrenSelect = $connection->select()
+                                     ->from($tmpTable, ['identifier'])
+                                     ->where('parent = :id');
 
         /** @var array $row */
         while ($row = $query->fetch()) {
@@ -1832,7 +1836,10 @@ class Product extends JobImport
                 }
 
                 /** @var array $children */
-                $children = explode(',', $row['_children']);
+                $children = $connection->fetchCol(
+                    $childrenSelect,
+                    ['id' => $row['identifier']]
+                );
                 /** @var string $child */
                 foreach ($children as $child) {
                     /** @var int $childId */


### PR DESCRIPTION
It changes the linking of configurables to use a sub query for each configurable, to avoid the limit of 1024 characters that group_concat has.

It was tested on a store that has a few dozens of configurables with ~3000 children each, and it finish in a couple of minutes.

It should probably be tested on a configuration with many configurables with few children each, but it's just an extra query per model.

Fixes #242 