### PR TITLE
Require enterprise api client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "magento/module-catalog": ">=100.0.1",
     "magento/module-eav": ">=100.0.1",
     "magento/module-store": ">=100.0.1",
-    "akeneo/api-php-client": "^6.0",
+    "akeneo/api-php-client-ee": "^6.0",
     "php-http/guzzle6-adapter": "^2.0",
     "http-interop/http-factory-guzzle": "^1.0"
   },


### PR DESCRIPTION
There are references in docblocks to `AkeneoPimEnterpriseClientInterface`. Also makes it easier to extend module without having to require enterprise api client