### PR TITLE
Use factory class to create AkeneoPimClientBuilder instance

### DIFF
--- a/Helper/Authenticator.php
+++ b/Helper/Authenticator.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Connector\Helper;
 
-use Akeneo\Pim\ApiClient\AkeneoPimClientInterface;
-use Akeneo\Pim\ApiClient\AkeneoPimClientBuilder;
+use Akeneo\Connector\Model\AkeneoPimClientBuilderFactory;
 use Akeneo\Connector\Helper\Config as ConfigHelper;
+use Akeneo\Pim\ApiClient\AkeneoPimClientInterface;
 use Http\Adapter\Guzzle6\Client;
 use Http\Factory\Guzzle\StreamFactory;
 use Http\Factory\Guzzle\RequestFactory;
@@ -21,22 +23,20 @@ use Http\Factory\Guzzle\RequestFactory;
  */
 class Authenticator
 {
-    /**
-     * This variable contains a ConfigHelper
-     *
-     * @var ConfigHelper $configHelper
-     */
-    protected $configHelper;
+    /** @var ConfigHelper $configHelper */
+    private $configHelper;
+
+    /** @var AkeneoPimClientBuilderFactory $clientBuilderFactory */
+    private $clientBuilderFactory;
 
     /**
-     * Authenticator constructor
-     *
-     * @param ConfigHelper $configHelper
+     * @param Config $configHelper
+     * @param AkeneoPimClientBuilderFactory $clientBuilderFactory
      */
-    public function __construct(
-        ConfigHelper $configHelper
-    ) {
+    public function __construct(ConfigHelper $configHelper, AkeneoPimClientBuilderFactory $clientBuilderFactory)
+    {
         $this->configHelper = $configHelper;
+        $this->clientBuilderFactory = $clientBuilderFactory;
     }
 
     /**
@@ -46,24 +46,17 @@ class Authenticator
      */
     public function getAkeneoApiClient()
     {
-        /** @var string $baseUri */
         $baseUri = $this->configHelper->getAkeneoApiBaseUrl();
-        /** @var string $clientId */
         $clientId = $this->configHelper->getAkeneoApiClientId();
-        /** @var string $secret */
         $secret = $this->configHelper->getAkeneoApiClientSecret();
-        /** @var string $username */
         $username = $this->configHelper->getAkeneoApiUsername();
-        /** @var string $password */
         $password = $this->configHelper->getAkeneoApiPassword();
 
         if (!$baseUri || !$clientId || !$secret || !$username || !$password) {
             return false;
         }
 
-        /** @var AkeneoPimClientBuilder $akeneoClientBuilder */
-        $akeneoClientBuilder = new AkeneoPimClientBuilder($baseUri);
-
+        $akeneoClientBuilder = $this->clientBuilderFactory->create(['baseUri' => $baseUri]);
         $akeneoClientBuilder->setHttpClient(new Client());
         $akeneoClientBuilder->setStreamFactory(new StreamFactory());
         $akeneoClientBuilder->setRequestFactory(new RequestFactory());

--- a/Model/AkeneoPimClientBuilderFactory.php
+++ b/Model/AkeneoPimClientBuilderFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connector\Model;
+
+use Akeneo\Pim\ApiClient\AkeneoPimClientBuilder;
+use Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder;
+use Magento\Framework\ObjectManagerInterface;
+
+class AkeneoPimClientBuilderFactory
+{
+    /** @var ObjectManagerInterface $objectManager */
+    private $objectManager = null;
+
+    /** @var string $instanceName */
+    private $instanceName = null;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     * @param string $instanceName
+     */
+    public function __construct(ObjectManagerInterface $objectManager, $instanceName = AkeneoPimClientBuilder::class)
+    {
+        $this->objectManager = $objectManager;
+        $this->instanceName = $instanceName;
+    }
+
+    /**
+     * Create class instance with specified parameters.
+     *
+     * @param array $data
+     *
+     * @return AkeneoPimClientBuilder|AkeneoPimEnterpriseClientBuilder
+     */
+    public function create(array $data = [])
+    {
+        return $this->objectManager->create($this->instanceName, $data);
+    }
+}


### PR DESCRIPTION
Using a factory will make it easier to replace the instance with `AkeneoPimEnterpriseClientBuilder` using argument replacement in `di.xml`. Now we can simply replace it and use enterprise endpoints.

```XML
<type name="Akeneo\Connector\Model\AkeneoPimClientBuilderFactory">
    <arguments>
        <argument name="instanceName" xsi:type="string">Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder</argument>
    </arguments>
</type>
```