### PR TITLE
BugFix: File import 0 Bytes.

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1493,7 +1493,9 @@ class Product extends JobImport
                 if (!$this->configHelper->mediaFileExists($filePath)) {
                     /** @var ResponseInterface $binary */
                     $binary = $this->akeneoClient->getProductMediaFileApi()->download($row[$attribute]);
-                    $this->configHelper->saveMediaFile($filePath, $binary);
+                    /** @var string $fileContents */
+                    $fileContents = $binary->getBody()->getContents();
+                    $this->configHelper->saveMediaFile($filePath, $fileContents);
                 }
 
                 // Change the Akeneo file path to Magento file path


### PR DESCRIPTION
When importing files this error occurs: Warning: strlen() expects parameter 1 to be string, object given.
Probably when changed to the new php-http/guzzle6-adapter 2.0 probably forgot that the outcome is object instead of a string. So new files will be created in the file system and have no contents eg. 0 Bytes.
FYI: For the image import around line 3096 the change was made this is correct implemented.