### PR TITLE
Fix incompatibility with Akeneo 3.1

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -979,7 +979,7 @@ class Product extends JobImport
             '_type_id'           => new Expr('"configurable"'),
             '_options_container' => new Expr('"container1"'),
             '_axis'              => 'v.axis',
-            'family'             => 'v.family',
+            'family'             => $connection->tableColumnExists($productModelTable, 'family') ? 'v.family' : 'e.family',
             'categories'         => 'v.categories',
         ];
 


### PR DESCRIPTION
With Akeneo 3.1, fix issue in product job due to missing data in API response "family" => https://api.akeneo.com/api-reference.html#get_product_models
 family (string) • Family code from which the product inherits its attributes and attributes requirements (since the 3.2)