### PR TITLE
Missing Family data in Product Model API (in Akeneo 3.1)

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -1005,7 +1005,7 @@ class Product extends JobImport
             '_type_id'           => new Expr('"configurable"'),
             '_options_container' => new Expr('"container1"'),
             '_axis'              => 'v.axis',
-            'family'             => $connection->tableColumnExists($productModelTable, 'family') ? 'v.family' : 'e.family',
+            'family'             => new Expr('"' . $this->getFamily() . '"'),
             'categories'         => 'v.categories',
         ];
 


### PR DESCRIPTION
Fix Akeneo 3.1 issue with Product Model API and Family missing data