### PR TITLE
Fix import of categories

### DIFF
--- a/Job/Category.php
+++ b/Job/Category.php
@@ -600,8 +600,6 @@ class Category extends Import
             $values['row_id'] = 'IFNULL (p.row_id, _entity_id)'; // on category creation, row_id is null
         }
 
-        /** @var \Magento\Framework\DB\Select $parents */
-        $parents = $connection->select()->from($tmpTable, $values);
         $connection->query(
             $connection->insertFromSelect(
                 $parents,


### PR DESCRIPTION
fix #436 #444

We create the `$parents` variable, add 2 left join in `addJoinForContentStagingCategory` and reset the variable, so when we execute the query the 2 joins are missing