### PR TITLE
Added position number to image import

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -3213,6 +3213,7 @@ class Product extends JobImport
         while (($row = $query->fetch())) {
             /** @var array $files */
             $files = [];
+            $positionCounter = 0;
             foreach ($gallery as $image) {
                 if (!isset($row[$image])) {
                     continue;
@@ -3297,9 +3298,10 @@ class Product extends JobImport
                     'store_id'        => 0,
                     $columnIdentifier => $row[$columnIdentifier],
                     'label'           => '',
-                    'position'        => 0,
+                    'position'        => $positionCounter,
                     'disabled'        => 0,
                 ];
+                $positionCounter++;
 
                 if ($recordId != 0) {
                     $data['record_id'] = $recordId;


### PR DESCRIPTION
Because images are always imported with position 0, the order in which images are sorted is based on value_id or record_id of the image. This can lead to incorrect orders, since the last imported image has the highest record_id.

This PR gives each image a position, at the order of import. The first imported image is image 0, the second is image 1, etc.