### PR TITLE
Feature/attributes not scopable localizable

### DIFF
--- a/Job/Attribute.php
+++ b/Job/Attribute.php
@@ -569,10 +569,10 @@ class Attribute extends Import
             /* Retrieve attribute scope */
             /** @var int $global */
             $global = ScopedAttributeInterface::SCOPE_GLOBAL; // Global
-            if ($row['scopable'] === 1) {
+            if ((int) $row['scopable'] === 1) {
                 $global = ScopedAttributeInterface::SCOPE_WEBSITE; // Website
             }
-            if ($row['localizable'] === 1 || $row['type'] === self::PIM_CATALOG_TABLE) {
+            if ((int) $row['localizable'] === 1 || $row['type'] === self::PIM_CATALOG_TABLE) {
                 $global = ScopedAttributeInterface::SCOPE_STORE; // Store View
             }
             /** @var array $data */


### PR DESCRIPTION
#490 

After a Product Attribute import Job we have attributes that are set as Global Scope even though they are either marked as scopable or localizable. We think this is because of changes that we're made in #490 since it tries to compare string with int values with the identical operator.