### PR TITLE
Update default product status for all supported types (not only for simple)

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -981,7 +981,7 @@ class Product extends JobImport
             $connection->update(
                 $tmpTable,
                 ['_status' => new Expr('IF(`enabled` <> 1, 2, 1)')],
-                ['_type_id = ?' => 'simple']
+                ['_type_id IN (?)' => $this->allowedTypeId]
             );
         }
 


### PR DESCRIPTION
During products import job on addRequiredData step, the default status for entities are updated based on akeneo "enabled" value, but it is updated only for "simple" product type (should be for all supported product types), that leads to an error that "disabled" status is set for other than "simple" types (eg "virtual").