### PR TITLE
fixed 'syntax error' with an empty advanced filter

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -895,7 +895,7 @@ class Config
     {
         $filters = $this->scopeConfig->getValue(self::PRODUCTS_FILTERS_ADVANCED_FILTER);
 
-        return $this->jsonSerializer->unserialize($filters);
+        return !empty($filters) ? $this->jsonSerializer->unserialize($filters) : [];
     }
 
     /**
@@ -907,7 +907,7 @@ class Config
     {
         $filters = $this->scopeConfig->getValue(self::PRODUCTS_MODEL_FILTERS_ADVANCED_FILTER);
 
-        return $this->jsonSerializer->unserialize($filters);
+        return !empty($filters) ? $this->jsonSerializer->unserialize($filters) : [];
     }
 
     /**


### PR DESCRIPTION
When using Advanced filter mode and leaving one filter empty an error is thrown on product import:
`Unable to serialize value. Error: syntax error`

This is because `Magento\Framework\Serialize\Serializer\Json` throws the error when trying to unserialize an empty string.
To solve this issue an empty array will be returned if no filter is set without calling the unserializer.