### PR TITLE
Hotfix image attributes not assigning to configured image.

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -3943,6 +3943,10 @@ class Product extends JobImport
                         $columns = $this->configHelper->getMediaImportImagesColumns();
 
                         foreach ($columns as $column) {
+                            if ($column['column'] !== $image) {
+                                continue;
+                            }
+
                             /** @var string $columnName */
                             $columnName = $column['column'] . self::SUFFIX_SEPARATOR . $suffix;
                             /** @var mixed[] $mappings */


### PR DESCRIPTION
This small piece of code will check if $column['column'] is equal to $image in the foreach loop in the Product job. if its not it will continue, this will make the akeneo connector actually assign the configured attributes to the configured image.