### PR TITLE
Fix Deprecated Functionality: Creation of dynamic property Akeneo\Con…

### DIFF
--- a/Console/Command/AkeneoConnectorImportCommand.php
+++ b/Console/Command/AkeneoConnectorImportCommand.php
@@ -51,6 +51,12 @@ class AkeneoConnectorImportCommand extends Command
      * @var JobRepository $jobRepository
      */
     protected $jobRepository;
+    /**
+     * Description $configHelper field
+     *
+     * @var ConfigHelper $configHelper
+     */
+    protected $configHelper;
 
     /**
      * AkeneoConnectorImportCommand constructor


### PR DESCRIPTION
This fixes the following deprecation warning seen when using php 8.2

```
Deprecated Functionality: Creation of dynamic property Akeneo\Connector\Console\Command\AkeneoConnectorImportCommand\Interceptor::$configHelper is deprecated in /var/www/vendor/akeneo/module-magento2-connector-community/Console/Command/AkeneoConnectorImportCommand.php on line 74
```