### PR TITLE
Fixed undefined method error

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -517,7 +517,7 @@ class Product extends JobImport
             $modelFilters = $this->getProductModelFilters($family);
             foreach ($modelFilters as $filter) {
                 /** @var PageInterface $productModels */
-                $productModels = $akeneoClient->listPerPage(1, false, $filter);
+                $productModels = $akeneoClient->getProductModelApi()->listPerPage(1, false, $filter);
                 /** @var array $productModel */
                 $productModels = $productModels->getItems();
 


### PR DESCRIPTION
This fixes the error stated in https://github.com/akeneo/magento2-connector-community/issues/636. The product model api has to be fetched before you can access the listPerPage function.