### PR TITLE
Get Default WebsiteId via Default StoreView

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1294,7 +1294,7 @@ class Config
      */
     public function getDefaultWebsiteId()
     {
-        return $this->storeManager->getStore()->getWebsiteId();
+        return $this->storeManager->getDefaultStoreView()->getWebsiteId();
     }
 
     /**


### PR DESCRIPTION
The Default Website Id is used for mapping a default tax class to the Default Scope.

This works as intended when using the CLI command to import products. The function `getDefaultWebsiteId` return the correct default website id.

When we run the import via the schedule we get the website id of the admin website (0). This is not the correct default website id. And this website is also not mappable in the configuration under field `Default Tax Class`.

Imports via the schedule result in a Tax Class that is `None`.
