### PR TITLE
Fixed date format before saving into database

### DIFF
--- a/Executor/JobExecutor.php
+++ b/Executor/JobExecutor.php
@@ -353,7 +353,7 @@ class JobExecutor implements JobExecutorInterface
                     $isError = true;
                 }
 
-                $this->lastSuccessExecutedDate[$this->getCurrentJobClass()->getFamily()] = date('y-m-d H:i:s');
+                $this->lastSuccessExecutedDate[$this->getCurrentJobClass()->getFamily()] = date('Y-m-d H:i:s');
 
                 // If last family, force proceed with after run steps
                 if (array_slice($productFamiliesToImport, -1)[0] === $family
@@ -679,7 +679,7 @@ class JobExecutor implements JobExecutorInterface
         }
 
         if ($status === JobInterface::JOB_SCHEDULED) {
-            $job->setScheduledAt(date('y-m-d H:i:s'));
+            $job->setScheduledAt(date('Y-m-d H:i:s'));
         }
 
         $job->setStatus($status);
@@ -703,7 +703,7 @@ class JobExecutor implements JobExecutorInterface
             'akeneo_connector_import_start_' . strtolower($this->currentJob->getCode()),
             ['executor' => $this]
         );
-        $this->currentJob->setLastExecutedDate(date('y-m-d H:i:s'));
+        $this->currentJob->setLastExecutedDate(date('Y-m-d H:i:s'));
         $this->setJobStatus(JobInterface::JOB_PROCESSING);
     }
 
@@ -737,7 +737,7 @@ class JobExecutor implements JobExecutorInterface
         }
 
         if ($this->currentJob->getCode() === JobExecutor::IMPORT_CODE_PRODUCT) {
-            $this->currentJob->setLastSuccessDate(date('y-m-d H:i:s'));
+            $this->currentJob->setLastSuccessDate(date('Y-m-d H:i:s'));
             $this->currentJob->setLastSuccessExecutedDate($this->json->serialize($this->lastSuccessExecutedDate));
 
             if ($this->currentJob->getStatus() === JobInterface::JOB_ERROR) {
@@ -747,7 +747,7 @@ class JobExecutor implements JobExecutorInterface
 
         if ($error === null && $this->currentJob->getStatus() !== JobInterface::JOB_ERROR) {
             if ($this->currentJob->getCode() !== JobExecutor::IMPORT_CODE_PRODUCT) {
-                $this->currentJob->setLastSuccessDate(date('y-m-d H:i:s'));
+                $this->currentJob->setLastSuccessDate(date('Y-m-d H:i:s'));
                 $this->currentJob->setLastSuccessExecutedDate($this->currentJob->getLastExecutedDate());
             }
             $this->setJobStatus(JobInterface::JOB_SUCCESS);


### PR DESCRIPTION
Those changes fixes issue caused by https://github.com/akeneo/magento2-connector-community/commit/67f58c233ac698781054777751ad438db2d0e321

When `last_success_executed_date` was datetime it was saved correctly into the database. But by changing it into text Mysql is no longer fixing date format while saving into database.
As result date is saved as `23-05-16 11:26:55` instead of `2023-05-16 11:26:55`.
When this date is used as filter in `Since last successful import` Products process it downloads all the products on each run of import instead of only modified.