### PR TITLE
Limit number of rows returned from product/website assigment query to…

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -2909,7 +2909,7 @@ class Product extends JobImport
                         'product_id' => '_entity_id',
                         'website_id' => new Expr($id),
                     ]
-                );
+                )->limit(1);
 
                 $connection->query(
                     $connection->insertFromSelect(


### PR DESCRIPTION
When using connector with a Magento site that have a lot o websites/storeviews performance of connector can be really poor because of this query in setWebsites method:

   $select = $connection->select()->from(
                    $tmpTable,
                    [
                        'product_id' => '_entity_id',
                        'website_id' => new Expr($id),
                    ]
                );

It unnecessarily loads whole products list in every foreach step for every product as this is translated into:

SELECT 104084 AS product_id, 13 AS website_id FROM tmp_akeneo_connector_entities_product

If you have 100.000 products you will receive 100k rows with  104084, 13 ;-)


Quick fix is to limit number of rows returned to only one as the result of this query is used by antother query here:

 $connection->query(
                    $connection->insertFromSelect(
                        $select,
                        $this->entitiesHelper->getTable('catalog_product_website'),
                        ['product_id', 'website_id'],
                        AdapterInterface::INSERT_ON_DUPLICATE
                    )
                );

And here only one product_id and one website_is are being used ;-)

The second query can be also replaced by normal insert - not insert from select in this case.


