### PR TITLE
Release/104.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -455,3 +455,8 @@
 
 ### Version 104.0.4 :
 * PGTO-376: Fix grouped product association with uuid
+
+### Version 104.0.5 :
+* PGTO-388: Fix table names when tables are prefixed
+* PGTO-389: Fix UUID retro-compatibility when sku is missing
+* PGTO-390: does not flush cache and refresh index until the last product family

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,3 +448,7 @@
 ### Version 104.0.2 :
 * PGTO-369: Fix product status assignment regression
 * PGTO-363: Fix visibility update
+
+### Version 104.0.3 :
+* PGTO-378: Fix product without category attribution
+* PGTO-380: Rebuild Visual Merchandiser Dynamic Categories

--- a/Helper/FamilyVariant.php
+++ b/Helper/FamilyVariant.php
@@ -248,7 +248,7 @@ class FamilyVariant
         $connection->query(
             $connection->updateFromSelect(
                 $query,
-                ['p' => $this->entitiesHelper->getTable($this->entitiesHelper->getTableName('product_model'))]
+                ['p' => $this->entitiesHelper->getTableName('product_model')]
             )
         );
 

--- a/Helper/Import/Entities.php
+++ b/Helper/Import/Entities.php
@@ -593,7 +593,7 @@ class Entities
             /** @var bool $rowIdExists */
             $rowIdExists = $this->rowIdColumnExists($table);
 
-            if ($rowIdExists && $entityTable === $this->getTablePrefix() . 'catalog_product_entity') {
+            if ($rowIdExists && $entityTable === 'catalog_product_entity') {
                 /** @var Select $select */
                 $select = $connection->select()->from(
                     $tableName,
@@ -604,7 +604,7 @@ class Entities
                     ]
                 );
                 $this->addJoinForContentStaging($select, [$identifier => 'row_id']);
-            } elseif ($rowIdExists && $entityTable === $this->getTablePrefix() . 'catalog_category_entity') {
+            } elseif ($rowIdExists && $entityTable === 'catalog_category_entity') {
                 /** @var Select $select */
                 $select = $connection->select()->from(
                     $tableName,

--- a/Helper/Import/Entities.php
+++ b/Helper/Import/Entities.php
@@ -985,7 +985,7 @@ class Entities
          * (they are not yet in catalog_category_entity)
          */
         $select->joinLeft(
-            ['p' => 'catalog_category_entity'],
+            ['p' => $this->getTable('catalog_category_entity')],
             '_entity_id = p.entity_id',
             $cols
         )
@@ -993,7 +993,7 @@ class Entities
              * retrieve all the staging update for the givens entities. We use "join left" to get the original entity
              */
             ->joinLeft(
-                ['s' => 'staging_update'],
+                ['s' => $this->getTable('staging_update')],
                 'p.created_in = s.id',
                 []
             );

--- a/Helper/Import/Option.php
+++ b/Helper/Import/Option.php
@@ -87,15 +87,15 @@ class Option extends Entities
                 ['t' => $tableName],
                 $columnToSelect
             )->joinInner(
-                ['e' => 'eav_attribute_option_value'],
+                ['e' => $this->getTable('eav_attribute_option_value')],
                 $condition,
                 []
             )->joinInner(
-                ['o' => 'eav_attribute_option'],
+                ['o' => $this->getTable('eav_attribute_option')],
                 'o.`option_id` = e.`option_id`',
                 ['option_id']
             )->joinInner(
-                ['a' => 'eav_attribute'],
+                ['a' => $this->getTable('eav_attribute')],
                 'o.`attribute_id` = a.`attribute_id` AND t.`attribute` = a.`attribute_code`',
                 []
             )->where('e.store_id = ?', 0)->where('a.entity_type_id', $entityTypeId);

--- a/Job/Product.php
+++ b/Job/Product.php
@@ -2053,7 +2053,9 @@ class Product extends JobImport
         /** @var string $statusAttributeId */
         $statusAttributeId = $this->eavAttribute->getIdByCode('catalog_product', 'status');
         /** @var string $identifierColumn */
-        $identifierColumn = $this->entitiesHelper->getColumnIdentifier('catalog_product_entity_int');
+        $identifierColumn = $this->entitiesHelper->getColumnIdentifier(
+            $this->entitiesHelper->getTable('catalog_product_entity_int')
+        );
         /** @var string $productTable */
         $productTable = $this->entitiesHelper->getTable('catalog_product_entity');
         /** @var string[] $pKeyColumn */

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "nyholm/psr7": "^1.5"
   },
   "type": "magento2-module",
-  "version": "104.0.2",
+  "version": "104.0.3",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "nyholm/psr7": "^1.5"
   },
   "type": "magento2-module",
-  "version": "104.0.4",
+  "version": "104.0.5",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
Version 104.0.5:

* PGTO-388: Fix table names when tables are prefixed
* PGTO-389: Fix UUID retro-compatibility when sku is missing
* PGTO-390: does not flush cache and refresh index until the last product family