### PR TITLE
fix/665 :: Moved 'children_count' = 0 expression for new categories only

### DIFF
--- a/Job/Category.php
+++ b/Job/Category.php
@@ -596,7 +596,6 @@ class Category extends Import
             'path'             => 'path',
             'position'         => 'position',
             'level'            => 'level',
-            'children_count'   => new Expr('0'),
         ];
 
         /** @var Select $parents */
@@ -621,6 +620,7 @@ class Category extends Import
         /** @var array $values */
         $values = [
             'created_at' => new Expr('now()'),
+            'children_count'   => new Expr('0'),
         ];
         $connection->update($table, $values, 'created_at IS NULL');
 


### PR DESCRIPTION
Moved the 'children_count' to only set it to 0 if the category is new. Instead of doing this every time the category sync is running.

see full explaination in #665 