### PR TITLE
Resolves #668: Products Duplicated in Initial Mapping Using UUID and Error on Subsequent Imports.

### DIFF
--- a/Helper/Import/Product.php
+++ b/Helper/Import/Product.php
@@ -451,7 +451,7 @@ class Product extends Entities
         $existingEntities = array_column($existingEntities, 'entity_id');
 
         // Get all entities that are being imported and already present in Magento
-        $select = $connection->select()->from(['t' => $tableName], ['sku' => 't.identifier'])->joinInner(
+        $select = $connection->select()->from(['t' => $tableName], ['code' => 't.' . $pimKey])->joinInner(
             ['e' => $entityTable],
             't.identifier = e.sku'
         );
@@ -463,7 +463,7 @@ class Product extends Entities
             if (!in_array($row['entity_id'], $existingEntities)) {
                 $values = [
                     'import'    => 'product',
-                    'code'      => $row['sku'],
+                    'code'      => $row['code'],
                     'entity_id' => $row['entity_id'],
                 ];
                 $connection->insertOnDuplicate($akeneoConnectorTable, $values);


### PR DESCRIPTION
The issue #668 is caused by the method `\Akeneo\Connector\Helper\Import\Product::matchEntity`, where the hardcoded column `identifier` is used instead of the provided `$pimKey` parameter to select the entity code.