### PR TITLE
Only remove products from categories managed in Akeneo

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -3049,10 +3049,11 @@ class Product extends JobImport
                 $virtualCategories = [0];
             }
             $virtualCategories = join(',', $virtualCategories);
+            $managedCategories = implode(',', array_values(array_map(fn($category) => $category['entity_id'], $categoryAkeneo)));
 
             $connection->delete(
                 $categoryProductTable,
-                new \Zend_Db_Expr("product_id IN ($productIds) AND category_id NOT IN ($virtualCategories) AND (product_id, category_id) NOT IN ($productCategoryExclusion)")
+                new \Zend_Db_Expr("product_id IN ($productIds) AND category_id NOT IN ($virtualCategories) AND category_id IN ($managedCategories) AND (product_id, category_id) NOT IN ($productCategoryExclusion)")
             );
         }
     }


### PR DESCRIPTION
If some categories are managed in Magento instead of Akeneo you are currently unable to link products to these categories as the akeneo connector will remove the product from any categories that it hasn't imported.

This change will keep the category link for categories that are not in the akeneo_connector_entities table.
So removing products from a category within Akeneo will still work as expected