### PR TITLE
Only fill completeness when we have products

### DIFF
--- a/Helper/Import/Product.php
+++ b/Helper/Import/Product.php
@@ -342,7 +342,7 @@ class Product extends Entities
             }
         }
 
-        if (isset($finalProducts)) {
+        if (!empty($finalProducts)) {
             $completeness['completenesses_' . $product['scope']] = $this->jsonSerializer->serialize($finalProducts);
         }
 


### PR DESCRIPTION
The `$finalProducts` is always set, it is set to an empty array before the loop. The `if` after the loop needs to check is the array is empty instead, just like the if check for `$completeness` below it.