### PR TITLE
Fixing last success executed date year

### DIFF
--- a/Executor/JobExecutor.php
+++ b/Executor/JobExecutor.php
@@ -357,7 +357,7 @@ class JobExecutor implements JobExecutorInterface
                     $isError = true;
                 }
 
-                $this->lastSuccessExecutedDate[$this->getCurrentJobClass()->getFamily()] = date('y-m-d H:i:s');
+                $this->lastSuccessExecutedDate[$this->getCurrentJobClass()->getFamily()] = date('Y-m-d H:i:s');
 
                 // If last family, force proceed with after run steps
                 if (array_slice($productFamiliesToImport, -1)[0] === $family


### PR DESCRIPTION
As we can see on akeneo documentation, akeneo filter is not support date with two digit representation of a year  (24-06-07) :
https://api.akeneo.com/documentation/filter.html