### PR TITLE
fix non-scopable localizable attribute import

### DIFF
--- a/Helper/Store.php
+++ b/Helper/Store.php
@@ -210,6 +210,7 @@ class Store
             $this->getStores(['channel_code']), // channel
             $this->getStores(['currency']), // USD
             $this->getStores(['channel_code', 'currency']), // channel-USD
+            $this->getStores(['lang', 'currency']), // en_US-USD
             $this->getStores(['lang', 'channel_code', 'currency']) // en_US-channel-USD
         );
 


### PR DESCRIPTION
This pull request fixes a bug that prevents the import of attributes marked as `localizable` but with `scopable=false.`

This issue leads to the creation of columns in the temporary table with the suffix "en_US-USD" when dealing with a price column. This suffix is not recognized afterward.

By adding this combination, it enables the import of prices in this case: `$this->getStores(['lang', 'currency'])`,