### PR TITLE
Remove unnecessary API calls to media

### DIFF
--- a/Job/Product.php
+++ b/Job/Product.php
@@ -4106,8 +4106,6 @@ class Product extends JobImport
         );
         /** @var string $productImageTable */
         $productImageTable = $this->entitiesHelper->getTable('catalog_product_entity_varchar');
-        /** @var string[] $medias */
-        $medias = [];
 
         $childOnlyImages = $this->configHelper->getMediaImportGalleryColumns(
             [ConfigHelper::PRODUCT_IMAGE_TYPE_CHILD]
@@ -4143,13 +4141,8 @@ class Product extends JobImport
                     continue;
                 }
 
-                if (!isset($medias[$row[$image]])) {
-                    $medias[$row[$image]] = $this->akeneoClient->getProductMediaFileApi()->get(
-                        $row[$image]
-                    );
-                }
                 /** @var string $name */
-                $name = $this->entitiesHelper->formatMediaName(basename($medias[$row[$image]]['code']));
+                $name = $this->entitiesHelper->formatMediaName(basename($row[$image]));
                 /** @var string $filePath */
                 $filePath = $this->configHelper->getMediaFullPath($name);
                 /** @var bool|string[] $databaseRecords */


### PR DESCRIPTION
we execute an API call for each and every image we're importing.
While at this moment the only value we use from that API call is the code.

This same code is required to do the API call in the first place
https://api.akeneo.com/api-reference.html#get_media_files__code_

So we can skip the call altogether since it's not used for anything else.

Improves (and potentially fixes): #638