### PR TITLE
Magento2.4.8 and PHP8.4 compatibility checking

### DIFF
--- a/Model/Backend/Json.php
+++ b/Model/Backend/Json.php
@@ -48,8 +48,8 @@ class Json extends Value
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         JsonSerializer $jsonSerializer,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);


### PR DESCRIPTION
Fix PHP 8.4 deprecation: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead